### PR TITLE
Return token as JSON, remove Room from grant

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,7 +20,8 @@ $token = new AccessToken(
 
 // Grant access to Video
 $grant = new VideoGrant();
-$grant->setRoom($room);
+//$grant->setRoom($room);
 $token->addGrant($grant);
 
-echo $token->toJWT();
+header('Content-Type: application/json; charset=utf-8');
+echo '{"identity":"'.$identity.'","token":"'.$token->toJWT().'" }';


### PR DESCRIPTION
In order for the [Video Quickstart JS](https://github.com/twilio/video-quickstart-js) to be able to process the token, it needs to be returned as a JSON.